### PR TITLE
Add current (and future-proof) footer copyright date

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -201,7 +201,7 @@ title: DEVit Conference - Thessaloniki 15 May 2015
               <li><a target="_blank" href="https://twitter.com/devitconf" class="fa fa-twitter"></a></li>
               <li class="followit-ribbon">&nbsp;</li>
             </ul>
-            <div class="copyrights">© 2014 <a href="https://github.com/skgtech/devit/graphs/contributors" target="_blank">SKGTech Contributors</a>, Licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">Creative Commons 4.0</a></div>
+            <div class="copyrights">© <script type="text/javascript">document.write(new Date().getFullYear()); </script> <a href="https://github.com/skgtech/devit/graphs/contributors" target="_blank">SKGTech Contributors</a>, Licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">Creative Commons 4.0</a></div>
 
           </div>
           <div class="col-sm-4 footer-fold">

--- a/app/index.html
+++ b/app/index.html
@@ -201,7 +201,7 @@ title: DEVit Conference - Thessaloniki 15 May 2015
               <li><a target="_blank" href="https://twitter.com/devitconf" class="fa fa-twitter"></a></li>
               <li class="followit-ribbon">&nbsp;</li>
             </ul>
-            <div class="copyrights">© <script type="text/javascript">document.write(new Date().getFullYear()); </script> <a href="https://github.com/skgtech/devit/graphs/contributors" target="_blank">SKGTech Contributors</a>, Licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">Creative Commons 4.0</a></div>
+            <div class="copyrights">© <span class="js-current-year">2015</span> <a href="https://github.com/skgtech/devit/graphs/contributors" target="_blank">SKGTech Contributors</a>, Licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">Creative Commons 4.0</a></div>
 
           </div>
           <div class="col-sm-4 footer-fold">

--- a/app/js/devit-custom.js
+++ b/app/js/devit-custom.js
@@ -7,6 +7,7 @@
 
     init: function () {
       devit.getSocialCounts();
+      devit.setCurrentYear();
     },
 
     getSocialCounts: function () {
@@ -32,6 +33,11 @@
         return ('' + c)[0] + 'k';
       else
         return c;
+    },
+
+    setCurrentYear: function () {
+      var currentYear = new Date().getFullYear();
+      $('.js-current-year').text(currentYear);
     }
   };
 


### PR DESCRIPTION
Addresses #30.

Adds a script that automatically updates the year in the footer copyright section.