### PR TITLE
Add support for abbreviating share numbers larger than 9999

### DIFF
--- a/app/js/devit-custom.js
+++ b/app/js/devit-custom.js
@@ -29,10 +29,13 @@
     _getK: function(n) {
       var c = parseInt(n);
 
-      if(c > 1000)
-        return ('' + c)[0] + 'k';
-      else
+      if (c > 9999 && c <= 999999) {
+        return parseFloat((c / 1000).toFixed(1)) + 'k';
+      } else if (c > 999999) {
+        return parseFloat((c / 1000000).toFixed(1)) + 'm';
+      } else {
         return c;
+      }
     },
 
     setCurrentYear: function () {

--- a/app/js/devit-custom.js
+++ b/app/js/devit-custom.js
@@ -14,19 +14,19 @@
       $.getJSON(
         "http://urls.api.twitter.com/1/urls/count.json?url=" + url + "&callback=?",
         function (json) {
-          $('.js-tw-count').text(devit._getK(json.count));
+          $('.js-tw-count').text(devit.siAbbrevCount(json.count));
         }
       );
 
       $.getJSON(
         "http://graph.facebook.com/" + url,
         function (json) {
-          $('.js-fb-count').text(devit._getK(json.shares));
+          $('.js-fb-count').text(devit.siAbbrevCount(json.shares));
         }
       );
     },
 
-    _getK: function(n) {
+    siAbbrevCount: function(n) {
       var c = parseInt(n);
 
       if (c > 9999 && c <= 999999) {


### PR DESCRIPTION
Adresses: #34 
_getK() function modified to group share count greater than 9999 on the thousands and millions(!) also showing one decimal digit. If decimal is zero it's omitted.

Example:
12345->12.3k
123456->123.4k
1234567->1.2m
10000000->10m

Note that the number returned is a string(due to toFixed()), but since it's only for appearance purposes it poses no problem.