### PR TITLE
Fix typo in Sponsorship page

### DIFF
--- a/pages/sponsorship/2017/index.html
+++ b/pages/sponsorship/2017/index.html
@@ -146,7 +146,7 @@ custom_js:
           <td class="text-center">10</td>
         </tr>
         <tr>
-          <th>Normal ticket discount in addition to the complimentary pack:/th>
+          <th>Normal ticket discount in addition to the complimentary pack</th>
           <td class="text-center">20%</td>
           <td class="text-center">20%</td>
           <td class="text-center">20%</td>


### PR DESCRIPTION
Fixes a tiny typo I saw while reading the Sponsorships page.

Aside: Can't find either `CHANGELOG.md` nor the `#Release History` section in `README.md` that is mentioned in the contribution guidelines.