### PR TITLE
Schedule Fixes v1

### DIFF
--- a/_data/schedule/2018.yml
+++ b/_data/schedule/2018.yml
@@ -121,6 +121,7 @@ workshops:
     duration: 120
     room: room_01
     day: workshops
+    part: part_1
 
   - type: 'fa-utensils'
     title: Lunch
@@ -137,6 +138,7 @@ workshops:
     duration: 120
     room: room_01
     day: workshops
+    part: part_2
 
   - type: 'fa-coffee'
     title: Coffee Break
@@ -153,9 +155,10 @@ workshops:
     duration: 120
     room: room_01
     day: workshops
+    part: part_3
 
   - type: 'fa-hourglass-end'
-    title: End of Workshop
+    title: End of Workshop Day
     hours: 19
     mins: '00'
     room: room_01
@@ -176,6 +179,7 @@ workshops:
     duration: 120
     room: room_02
     day: workshops
+    part: part_1
 
   - type: 'fa-utensils'
     title: Lunch
@@ -192,6 +196,7 @@ workshops:
     duration: 120
     room: room_02
     day: workshops
+    part: part_2
 
   - type: 'fa-coffee'
     title: Coffee Break
@@ -208,9 +213,10 @@ workshops:
     duration: 120
     room: room_02
     day: workshops
+    part: part_3
 
   - type: 'fa-hourglass-end'
-    title: End of Workshop
+    title: End of Workshop Day
     hours: 19
     mins: '00'
     room: room_02
@@ -265,7 +271,7 @@ workshops:
     day: workshops
 
   - type: 'fa-hourglass-end'
-    title: End of Workshop
+    title: End of Workshop Day
     hours: 19
     mins: '00'
     room: room_03
@@ -320,7 +326,7 @@ workshops:
     day: workshops
 
   - type: 'fa-hourglass-end'
-    title: End of Workshop
+    title: End of Workshop Day
     hours: 19
     mins: '00'
     room: room_04
@@ -375,7 +381,7 @@ workshops:
     day: workshops
 
   - type: 'fa-hourglass-end'
-    title: End of Workshop
+    title: End of Workshop Day
     hours: 19
     mins: '00'
     room: room_05

--- a/_data/talks/2018.yml
+++ b/_data/talks/2018.yml
@@ -336,10 +336,21 @@
   speaker: julien_simon
   type: Talk
 
-- title: "To be announced"
+- title: "Machine Learning and Deep Learning in Python"
   ticket: single
   speaker: julien_simon
   type: Workshop
+  description: "<p>Skill Level: intermediate</p><p>Prerequisites: familiarity with Linux CLI, 
+  familiarity with Python/JSON/YAML, AWS account (it takes 24 hours to validate new accounts, 
+  so please do this before the workshop).</p><p>Description: the goal of this coding workshop 
+  is to teach you the basics of Machine Learning (ML) and Deep Learning (DL) with the Python 
+  language and popular open source libraries.</p><p>The main topics we will cover:</p>
+  <ul><li>classic ML algorithms: linear regression, classification, clustering, dimensionality reduction.
+  </li><li>DL concepts: neural networks, activation functions, back propagation, optimisation.</li><li>
+  Open source libraries for ML/DL: sckit-learn, Apache MXNet, TensorFlow, Keras, Spark MLlib.</li><li>
+  Running ML/DL on AWS with Amazon SageMaker: each participant will receive $100 in AWS credits :)</li></ul>"
+  buyLink: https://www.eventora.com/en/Events/devit_conference_2018/Order?ttId=26200&ttQuantity=1&r
+
 
 - title: "Zero to Swagger in Moments"
   ticket: single

--- a/_includes/components/scheduleEntry.html
+++ b/_includes/components/scheduleEntry.html
@@ -2,50 +2,153 @@
 {% assign entry = include.entry %}
 {% assign talk = include.talk %}
 
-<div class="schedule-item">
-  <div class="schedule-item__hour">{{entry.hours}}:{{entry.mins}}</div>
+{% if talk.type != 'Workshop' %}
+  <div class="schedule-item">
+    <div class="schedule-item__hour">{{entry.hours}}:{{entry.mins}}</div>
 
-  {% if speaker %}
-    <div class="schedule-item__image">
-      {% if speaker == "tba" %}
-        <img
-          class="lazy"
-          src="/assets/images/new/placeholder-profile-photo.svg"
-          alt="To be announced">
-      {% else %}
-        <div class="schedule-item__image">
+    {% if speaker %}
+      <div class="schedule-item__image">
+        {% if speaker == "tba" %}
           <img
             class="lazy"
             src="/assets/images/new/placeholder-profile-photo.svg"
-            data-src="/assets/images/speakers/{{year}}/{{ speaker.image_filename }}"
-            alt="{{ speaker.first_name }} {{ speaker.last_name }}">
-        </div>
-      {% endif %}
-    </div>
-  {% else %}
-    <div class="schedule-item__image">
-      <span>
-        <i class="fas {{entry.type}}"></i>
-      </span>
-    </div>
-  {% endif %}
+            alt="To be announced">
+        {% else %}
+            <img
+              class="lazy"
+              src="/assets/images/new/placeholder-profile-photo.svg"
+              data-src="/assets/images/speakers/{{year}}/{{ speaker.image_filename }}"
+              alt="{{ speaker.first_name }} {{ speaker.last_name }}">
 
-  <div class="schedule-item__main">
-    {% if speaker %}
-      {% if speaker == "tba" %}
-        <div class="schedule-item__title">
-          To Be Announced
-        </div>
-      {% else %}
-        <div class="schedule-item__subtitle">{{speaker.first_name}} {{speaker.last_name}}</div>
-        <a
-          href="/speakers/{{ speaker.url }}#{{talk.title | slugify}}"
-          class="schedule-item__title">
-            {{talk.title}}
-        </a>
-      {% endif %}
+        {% endif %}
+      </div>
     {% else %}
-      <div class="schedule-item__title">{{entry.title}}</div>
+      <div class="schedule-item__image">
+        <span>
+          <i class="fas {{entry.type}}"></i>
+        </span>
+      </div>
     {% endif %}
+
+    <div class="schedule-item__main">
+      {% if speaker %}
+        {% if speaker == "tba" %} 
+          <div class="schedule-item__title">
+            To Be Announced
+          </div>
+        {% else %}
+          <div class="schedule-item__subtitle">{{speaker.first_name}} {{speaker.last_name}}</div>
+          <a
+            href="/speakers/{{ speaker.url }}#{{talk.title | slugify}}"
+            class="schedule-item__title">
+              {{talk.title}}
+          </a>
+
+          <div class="tags">
+            {% for tag in talk.tags %}
+            <span class="tag">
+              {{tag}}
+            </span>
+            {% endfor %}
+          </div>
+
+        {% endif %}
+      {% else %}
+        <div class="schedule-item__title" style="padding-top: 10px;">{{entry.title}}</div>
+      {% endif %}
+    </div>
   </div>
-</div>
+
+{% else %}
+
+  <div class="schedule-item">
+    <div class="schedule-item__hour">{{entry.hours}}:{{entry.mins}}</div>
+
+    {% if speaker %}
+      <div class="schedule-item__image">
+        {% if speaker == "tba" %}
+          <img
+            class="lazy"
+            src="/assets/images/new/placeholder-profile-photo.svg"
+            alt="To be announced">
+        {% else %}
+            <img
+              class="lazy"
+              src="/assets/images/new/placeholder-profile-photo.svg"
+              data-src="/assets/images/speakers/{{year}}/{{ speaker.image_filename }}"
+              alt="{{ speaker.first_name }} {{ speaker.last_name }}">
+        {% endif %}
+      </div>
+    {% else %}
+      <div class="schedule-item__image">
+        <span>
+          <i class="fas {{entry.type}}"></i>
+        </span>
+      </div>
+    {% endif %}
+
+    <div class="schedule-item__buy">
+      {% if speaker %}
+        {% if speaker == "tba" %} 
+          <div class="schedule-item__title">
+            To Be Announced
+          </div>
+        {% else %}
+          <div class="schedule-item__subtitle">{{speaker.first_name}} {{speaker.last_name}}</div>
+          <a
+            href="/speakers/{{ speaker.url }}#{{talk.title | slugify}}"
+            class="schedule-item__title">
+              {% if entry.part %}
+                {% if entry.part == 'part_1' %}
+                  {{talk.title}} Part 1
+                {% elsif entry.part == 'part_2' %}
+                  {{talk.title}} Part 2
+                {% else %}
+                  {{talk.title}} Part 3
+                {% endif %} 
+              {% else %}
+                {{talk.title}} 
+              {% endif %}
+
+                <!-- {{talk.title}} 
+              }
+              {% if entry.part == 'part_1' %}
+                {{talk.title}} Part 1
+              {% else if entry.part == 'part_2' %}
+                {{talk.title}} Part 2
+              {% else if entry.part == 'part_3' %}
+                {{talk.title}} Part 3
+              {% else %}
+                {{talk.title}} 
+              {% endif %} -->
+              
+          </a>
+
+          <div class="tags">
+            {% for tag in talk.tags %}
+            <span class="tag">
+              {{tag}}
+            </span>
+            {% endfor %}
+          </div>
+
+        {% endif %}
+      {% else %}
+        <div class="schedule-item__title">{{entry.title}}</p></div>
+      {% endif %}
+    </div>
+
+     {% if talk.buyLink %}
+      <a
+        target="_blank"
+        rel="noopener"
+        class="schedule__item-cta btn btn-primary"
+        href="{{ talk.buyLink }}">
+        Buy now
+      </a>
+    {% endif %}
+
+   
+  </div>
+
+{% endif %}

--- a/_includes/components/session.html
+++ b/_includes/components/session.html
@@ -3,8 +3,8 @@
 
 <div class="sessions__item">
   <div class="sessions__item-img">
-    <img
-      class="lazy"
+    <img 
+      class="lazy" 
       src="/assets/images/new/placeholder-profile-photo.svg"
       data-src="/assets/images/speakers/{{site.data.config.currentYear}}/{{ speaker.image_filename }}"
       alt="{{ speaker.first_name }} {{ speaker.last_name }}">

--- a/_scss/blocks/schedule.scss
+++ b/_scss/blocks/schedule.scss
@@ -26,7 +26,7 @@
 
       a {
         color: #57585a;
-        opacity: 0.5;
+        opacity: 1;
       }
 
       &.active {
@@ -174,6 +174,24 @@
 
     // text-align: left;
     padding-top: 15px;
+  }
+
+  .schedule-item__buy {
+    @include make-md-column(6);
+
+    // text-align: left;
+    padding-top: 15px;
+  }
+
+  .schedule__item-cta {
+    margin: 0 24px;
+    -webkit-border-radius: 50px;
+    border-radius: 50px;
+    padding: 10px 32px;
+    font-size: 1em;
+    font-weight: normal;
+    text-transform: uppercase;
+    margin-top: 25px;
   }
 
   .schedule-item__title {

--- a/pages/schedule/index.html
+++ b/pages/schedule/index.html
@@ -13,7 +13,7 @@ custom_js:
   <div class="block__heading--dark text-center">
     Schedule
   </div>
-
+ 
   <div class="schedule">
     <div class="schedule__header">
       <ul class="schedule__tabs" role="tablist">
@@ -37,6 +37,13 @@ custom_js:
         <div role="tabpanel" class="tab-pane" id="workshops">
           <div class="workshops__header">
             <ul class="workshops__tabs" role="tablist">
+              
+             <!--  <li role="all" class="active" style="margin-right: 50px;">
+                <a href="#all" aria-controls="all" role="tab" data-toggle="tab">
+                  All Workshops
+                </a>
+              </li> -->
+
               <li role="room1" class="active">
                 <a href="#room1" aria-controls="room1" role="tab" data-toggle="tab">
                   Room 1
@@ -66,7 +73,29 @@ custom_js:
           </div>
           <div class="workshops__content">
             <div class="tab-content">
-              <div role="tabpanel" class="tab-pane active" id="room1">
+
+              <div role="tabpanel" class="tab-pane active" id="all">
+                <div class="schedule-list">
+                  {% assign year = site.data.config.currentYear %}
+                  {% for entry in site.data.schedule[year].workshops %}
+                    {% if entry.type == 'workshop' and entry.room == 'room_01' and entry.day == 'workshops' %}
+                      {% for talk in site.data.talks[year] %}
+                        {% if entry.speaker == talk.speaker and talk.type == 'Workshop' %}
+                          {% for speaker in site.data.speakers[year].speakers %}
+                            {% if speaker.url == entry.speaker %}
+                              {% include components/scheduleEntry.html speaker=speaker entry=entry talk=talk %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endif %}
+                      {% endfor %}
+                    {% elsif entry.type != 'talk'  and  entry.room == 'room_01' and entry.day == 'workshops' %}
+                      {% include components/scheduleEntry.html entry=entry %}
+                    {% endif %}
+                 {% endfor %}
+                </div>
+              </div>
+
+              <div role="tabpanel" class="tab-pane" id="room1">
                 <div class="schedule-list">
                   {% assign year = site.data.config.currentYear %}
                   {% for entry in site.data.schedule[year].workshops %}

--- a/pages/workshops/index.html
+++ b/pages/workshops/index.html
@@ -6,7 +6,7 @@ permalink: /workshops
 ---
 
 {% include blocks/header.html page="workshops" %}
-
+ 
 <div class="block block-sessions text-center">
   <div class="container">
     <h1 class="block__heading--dark">


### PR DESCRIPTION
Fixes include:
1) Fix valign στα items που δεν ειναι sessions (attached)
2) Προσθήκη tags στα sessions, όπως στο /talks και /workshops
3) Προσθήκη CTA στα sessions, όπως στο /talks και /workshops
4) Workshops - προσθηκη Part 1, part2, part3  στον τίτλο των full day events
5) Workshops - στο τελος να μην λεει "end of workshop" αλλά "end of workshops day"
6) Οτι δεν ειναι workshop ( eg: registration) να γινει align to img με τα img των speaker στα workshops
7) Add julien_simon on workshops

According the tasks written on the Trello Board named "Schedule fixes"

TO BE DONE:  
1) Προσθήκη επιλογής All Workshops σαν πρωτο (default) tab, που θα έχει όλη τη λιστα με τα tabs
2) Προσθ'ηκη του room κάτω από την ώρα, στα workshops, με font όπως το ονομα του speaker
3) Workshops - προσθηκη υποτιτλου "Full-day workshop" ή "Morning/Noon/Evening workshops" ακριβώς πάνω από το registration  div, και τερμα αριστερα, με το font του Room