### PR TITLE
Add cookies notification block

### DIFF
--- a/_includes/blocks/privacy.html
+++ b/_includes/blocks/privacy.html
@@ -1,0 +1,40 @@
+<div class="container">
+  <div class="block">
+    <h1 class="block__heading--dark">
+      Privacy statement
+    </h1>
+    <p class="leading--dark">
+      Privacy matters but it can be confusing. This page explains our approach to privacy and how it affects you.
+    </p>
+
+
+      <h2>Measuring our visitors</h2>
+      <p>
+        We measure visitors to our website using&nbsp;
+        <a href="https://analytics.google.com/analytics/web/">Google Analytics</a>
+        and <a href="https://www.facebook.com/business/learn/facebook-ads-pixel">Facebook Pixel</a>.
+        These service record what pages you view within our site, how you arrived
+        at our site and some basic information about your computer.
+      </p>
+      <p>
+        The information we collect helps us understand what parts of our sites are
+        doing well, how people arrive at our site and so on. Like most websites, we
+        use this information to make our website better.
+      </p>
+      <p>
+        You can learn more about&nbsp;<a
+          title="Google Analytics' privacy policy"
+          href="http://www.google.com/analytics/learn/privacy.html"
+          >Google Analytics</a
+        >&nbsp;or&nbsp;<a
+          title="How to opt out of Google Analytics"
+          href="https://tools.google.com/dlpage/gaoptout"
+          >opt out if you wish</a
+        >. Google Analytics data is automatically deleted 26 months after your last
+        visit.
+      </p>
+      <p>Our website may link to external sites that are not operated by us. Please be aware that we have no control over the content and practices of these sites, and cannot accept responsibility or liability for their respective privacy policies.</p>
+      <p>Your continued use of our website will be regarded as acceptance of our practices around privacy and personal information. If you have any questions about how we handle user data and personal information, feel free to contact us.</p>
+    </div>
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,6 +82,29 @@
   {% endif %}
   <!-- End Facebook Pixel Code -->
 
+  <!-- Cookie consent -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"></script>
+  <script>
+  window.addEventListener("load", function(){
+  window.cookieconsent.initialise({
+    "palette": {
+      "popup": {
+        "background": "#f4f3f4",
+        "text": "#57585a"
+      },
+      "button": {
+        "background": "#00629e",
+        "text": "#ffffff"
+      }
+    },
+    "theme": "classic",
+    "content": {
+      "message": "🍪 We’re using cookies to understand our audience better.",
+      "link": "More info",
+      "href": "/privacy"
+    }
+  })});
+  </script>
 </head>
 <body>
 

--- a/_scss/blocks/cookie-consent.scss
+++ b/_scss/blocks/cookie-consent.scss
@@ -1,0 +1,323 @@
+.cc-window {
+  opacity: 1;
+  transition: opacity 1s ease;
+}
+
+.cc-window.cc-invisible {
+  opacity: 0;
+}
+
+.cc-animate.cc-revoke {
+  transition: transform 1s ease;
+}
+
+.cc-animate.cc-revoke.cc-top {
+  transform: translateY(-2em);
+}
+
+.cc-animate.cc-revoke.cc-bottom {
+  transform: translateY(2em);
+}
+
+.cc-animate.cc-revoke.cc-active.cc-bottom,
+.cc-animate.cc-revoke.cc-active.cc-top,
+.cc-revoke:hover {
+  transform: translateY(0);
+}
+
+.cc-grower {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 1s;
+}
+
+.cc-link,
+.cc-revoke:hover {
+  text-decoration: underline;
+}
+
+.cc-revoke,
+.cc-window {
+  position: fixed;
+  overflow: hidden;
+  box-sizing: border-box;
+  font-size: 85%;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  z-index: 9999;
+}
+
+.cc-window.cc-static {
+  position: static;
+}
+
+.cc-window.cc-floating {
+  padding: 2em;
+  max-width: 24em;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.cc-window.cc-banner {
+  border: 1px solid #ddd;
+  border-radius: 40px;
+  padding: 8px 8px 8px 12px;
+}
+
+.cc-revoke {
+  padding: 0.5em;
+}
+
+.cc-header {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.cc-btn,
+.cc-close,
+.cc-link,
+.cc-revoke {
+  cursor: pointer;
+}
+
+.cc-link {
+  opacity: 0.8;
+  display: inline-block;
+  padding: 0.2em;
+}
+
+.cc-link:hover {
+  opacity: 1;
+}
+
+.cc-link:active,
+.cc-link:visited {
+  color: initial;
+}
+
+.cc-btn {
+  display: block;
+  padding: 0.4em 0.8em;
+  font-size: 0.9em;
+  font-weight: 700;
+  border-width: 2px;
+  border-style: solid;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.cc-highlight .cc-btn:first-child {
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.cc-highlight .cc-btn:first-child:focus,
+.cc-highlight .cc-btn:first-child:hover {
+  background-color: transparent;
+  text-decoration: underline;
+}
+
+.cc-close {
+  display: block;
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  font-size: 1.6em;
+  opacity: 0.9;
+  line-height: 0.75;
+}
+
+.cc-close:focus,
+.cc-close:hover {
+  opacity: 1;
+}
+
+.cc-revoke.cc-top {
+  top: 0;
+  left: 3em;
+  border-bottom-left-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.cc-revoke.cc-bottom {
+  bottom: 10px;
+  right: 10px;
+}
+
+.cc-revoke.cc-left {
+  left: 3em;
+  right: unset;
+}
+
+.cc-revoke.cc-right {
+  right: 3em;
+  left: unset;
+}
+
+.cc-top {
+  top: 1em;
+}
+
+.cc-left {
+  left: 1em;
+}
+
+.cc-right {
+  right: 1em;
+}
+
+.cc-bottom {
+  bottom: 10px;
+  right: 10px;
+}
+
+.cc-floating > .cc-link {
+  margin-bottom: 1em;
+}
+
+.cc-floating .cc-message {
+  display: block;
+  margin-bottom: 1em;
+}
+
+.cc-window.cc-floating .cc-compliance {
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.cc-window.cc-banner {
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.cc-banner.cc-top {
+  left: 0;
+  right: 0;
+  top: 0;
+}
+
+.cc-banner .cc-message {
+  margin-right: 10px;
+}
+
+.cc-compliance {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+  align-items: center;
+  -ms-flex-line-pack: justify;
+  align-content: space-between;
+}
+
+.cc-floating .cc-compliance > .cc-btn {
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.cc-btn + .cc-btn {
+  margin-left: 0.5em;
+}
+
+@media print {
+  .cc-revoke,
+  .cc-window {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 900px) {
+  .cc-btn {
+    white-space: normal;
+  }
+}
+
+@media screen and (max-width: 414px) and (orientation: portrait),
+  screen and (max-width: 736px) and (orientation: landscape) {
+  .cc-window.cc-top {
+    top: 0;
+  }
+
+  .cc-window.cc-bottom {
+    bottom: 0;
+  }
+
+  .cc-window.cc-banner,
+  .cc-window.cc-floating,
+  .cc-window.cc-left,
+  .cc-window.cc-right {
+    left: 0;
+    right: 0;
+  }
+
+  .cc-window.cc-banner {
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+
+  .cc-window.cc-banner .cc-compliance {
+    -ms-flex: 1 1 auto;
+    flex: 1 1 auto;
+  }
+
+  .cc-window.cc-floating {
+    max-width: none;
+    margin: 10px;
+  }
+
+  .cc-window .cc-message {
+    margin-bottom: 1em;
+  }
+
+  .cc-window.cc-banner {
+    -ms-flex-align: unset;
+    align-items: unset;
+  }
+
+  .cc-window.cc-banner .cc-message {
+    margin-right: 0;
+  }
+}
+
+.cc-floating.cc-theme-classic {
+  padding: 1.2em;
+  border-radius: 5px;
+}
+
+.cc-floating.cc-type-info.cc-theme-classic .cc-compliance {
+  text-align: center;
+  display: inline;
+  -ms-flex: none;
+  flex: none;
+}
+
+.cc-theme-classic .cc-btn {
+  border-radius: 20px;
+}
+
+.cc-floating.cc-type-info.cc-theme-classic .cc-btn {
+  display: inline-block;
+}
+
+.cc-theme-edgeless.cc-window {
+  padding: 0;
+}
+
+.cc-floating.cc-theme-edgeless .cc-message {
+  margin: 2em 2em 1.5em;
+}
+
+.cc-banner.cc-theme-edgeless .cc-btn {
+  margin: 0;
+  padding: 0.8em 1.8em;
+  height: 100%;
+}
+
+.cc-banner.cc-theme-edgeless .cc-message {
+  margin-left: 1em;
+}
+
+.cc-floating.cc-theme-edgeless .cc-btn + .cc-btn {
+  margin-left: 0;
+}

--- a/_scss/main.scss
+++ b/_scss/main.scss
@@ -55,5 +55,6 @@ $font-size-h1:            floor(($font-size-base * 2.7)) !default; // ~36px
 @import "blocks/schedule";
 @import "blocks/index-item";
 @import "blocks/ticketing_widget";
+@import "blocks/cookie-consent";
 
 @import "bootstrap-override";

--- a/pages/privacy/index.html
+++ b/pages/privacy/index.html
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Privacy
+permalink: /privacy
+---
+
+{% include blocks/header.html %}
+{% include blocks/privacy.html %}
+{% include blocks/footer.html %}


### PR DESCRIPTION
https://trello.com/c/FQy5tzeL
This adds a small banner that informs the visitor about our cookies re: analytics/fb pixel. It looks like this:
![image](https://user-images.githubusercontent.com/1829897/53364273-20f68980-3947-11e9-9b3f-b90266ba82f0.png)
The privacy statement is in the [`/privacy` route](https://github.com/skgtech/devit/blob/f5aadeaa703165aabf4f1c904f1d59e1d0a56902/_includes/blocks/privacy.html), please take a look and propose any changes if need be.